### PR TITLE
Added Email Fire Alerts

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'core.apps.CoreConfig'

--- a/core/apps.py
+++ b/core/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 
 class CoreConfig(AppConfig):
     name = 'core'
+    
+    def ready(self):
+        from . import signals

--- a/core/signals.py
+++ b/core/signals.py
@@ -1,0 +1,26 @@
+from django.contrib.auth.models import User
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from .models import Ambulance, Fire, Police
+from django.core.mail import send_mail
+from django.conf import settings 
+
+@receiver(post_save, sender=Fire)
+def fire_alert(sender, instance=None, **kwargs):
+    """
+    A mail whenever a new fire incident is noticed and registered into the system.
+    """
+    if kwargs['created']:
+        subject='Fire incident!' #Subject of the mail
+        recipient_list = [] #User email list to be mailed
+        sender_mail = settings.EMAIL_HOST_USER # Sender Email  
+        content= "A fire incident has taken place in your locality! Please take care." # Body of the message
+        send_mail(
+            subject= subject, 
+            message=content, 
+            from_email= sender_mail, 
+            recipient_list=recipient_list, 
+            fail_silently=False
+        )
+    else:
+        pass

--- a/simplifyreport/settings.py
+++ b/simplifyreport/settings.py
@@ -136,3 +136,9 @@ MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 
 django_heroku.settings(locals())
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = 'smtp.gmail.com'
+EMAIL_USE_TLS = True
+EMAIL_PORT = 587
+EMAIL_HOST_PASSWORD='' #your email password here
+EMAIL_HOST_USER='' #your email address here.


### PR DESCRIPTION
I have added the email alerts functionality that sends the email alerts to a list of users whenever a new fire incident is posted into the database.

To check this, please set the variables in simplifyreport/settings.py (line 143 & 144) :
143. `EMAIL_HOST_PASSWORD='' #your email password here`
144. `EMAIL_HOST_USER='' #your email address here.`

Also, set the list of recipients in core/signals.py (line 15) :
15. `recipient_list = [] #User email list to be mailed`

Note: We can remove the recipient list with the list of users when the auth system is ready or we can add the an EmailField in User Profile model.
